### PR TITLE
Clean HTML tag and defer Chart.js loading

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en" data-zktls-injected="true"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<html lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Bitcoin Financial Strategy Simulator</title>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js" integrity="sha512-dmB7v8t5Bxs6u436hAuvnk2o6ig84yYI6FqdtYYdlcYNSeNBY0d5hDOGOZa2mYIZxZOKhHvJ3C0cIShJMqq+XQ==" crossorigin="anonymous" defer></script>
   <link rel="preconnect" href="https://fonts.googleapis.com/">
   <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- remove leftover injected attribute from HTML root tag
- load Chart.js with integrity check and defer attribute to avoid blocking rendering

## Testing
- `npx htmlhint index.htm` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8d6a62e8832bb254544cfaabe261